### PR TITLE
Fix Arduino avr-gcc tool path when "arduino-cli config dump" is empty

### DIFF
--- a/src/gui/editorwidget/debuggers/inodebugger.cpp
+++ b/src/gui/editorwidget/debuggers/inodebugger.cpp
@@ -5,6 +5,7 @@
 
 #include <QApplication>
 #include <QSettings>
+#include <QStandardPaths>
 //#include <QDebug>
 
 #include "inodebugger.h"
@@ -187,11 +188,25 @@ void InoDebugger::setToolPath( QString path )
             for( QString line : configLines )
             {
                 if( !line.contains("data: ") ) continue;
-                m_toolPath = QDir::fromNativeSeparators( line. split("data: ").last() )+"/packages/arduino/tools/avr-gcc/";
+                m_toolPath = QDir::fromNativeSeparators( line. split("data: ").last() );
+                break;
+            }
+
+            if (m_toolPath.isEmpty()) // Fix empty config
+            {
+#ifndef Q_OS_UNIX
+                m_toolPath = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)+"/Arduino15";
+#else
+                m_toolPath = QStandardPaths::writableLocation(QStandardPaths::HomeLocation)+"/.arduino15";
+#endif
+            }
+
+            if (!m_toolPath.isEmpty())
+            {
+                m_toolPath += "/packages/arduino/tools/avr-gcc/";
                 QDir toolDir( m_toolPath );
                 QStringList dirList = toolDir.entryList( QDir::Dirs, QDir::Name | QDir::Reversed );
                 if( !dirList.isEmpty() ) m_toolPath += dirList[0]+"/bin/";
-                break;
             }
 
             command = builder;


### PR DESCRIPTION
Latest Arduino IDE outputs empty configuration with:

```
$ ./arduino-cli config dump
{}
```
This causes that AVR tools cannot be found and debugger fails with:

```
Warning: avr-objdump executable not detected:
avr-objdump

Searching for variables... 0 variables found

Warning: avr-readelf executable not detected:
avr-readelf

Searching for Functions... 0 functions found

Warning: avr-size executable not detected:
avr-size

Warning: avr-addr2line executable not detected:
avr-addr2line

Mapping Flash to Source... 0 lines mapped

Error Starting Debugger
```
Tested with Arduino IDE v2.3.4 under Linux and Windows 10.